### PR TITLE
Add newline ZST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This changelog was added after the release of 1.0.0; changes before that are lef
 
 ## Unlreleased
 
+### Added
+- 0-size `Display` type for `Newline` in `separators`.
+
 ## 2.0.0
 
 2019-02-10

--- a/src/separators.rs
+++ b/src/separators.rs
@@ -90,6 +90,7 @@ macro_rules! const_separator {
 }
 
 const_separator! {
+    Newline(sep: '\n', repr: "newline", test: test_newline)
     Space(sep: ' ', repr:"space", test:test_space)
     Comma(sep: ',', repr: "`,`", test: test_comma)
     CommaSpace(sep: ", ", repr: "comma followed by space", test: test_comma_space)


### PR DESCRIPTION
#19 was mostly resolved with `2.0.0`, but is missing the `Newline` separator.

As I was not sure, if there was a reason for that, and I could use it, so I added it.

What do you think?

PS: #19 also mentions `CharSpace`, but I am not sure, what you mean by that.